### PR TITLE
Fix for multiple accordions on one page

### DIFF
--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -3,7 +3,8 @@ export default function decorate(block) {
   const items = block.querySelectorAll(':scope > div');
   let itemNumber = 1;
   const collection = document.createElement('div');
-  const uniqueId = Date.now();
+  const randNum = Math.random().toString();
+  const uniqueId = randNum.substring(2);
   items.forEach((i) => {
     const pieces = i.querySelectorAll('div');
     const heading = document.createElement('h4');


### PR DESCRIPTION
- Old js used date.now but the page could load fast enough to use the same number twice. Switched to math.random.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #36 
Test URLs:
- Before: https://main--uswds-hlx--jfoxx.hlx.page/
- After: https://36-accordion-ids--uswds-hlx--jfoxx.hlx.page/
